### PR TITLE
Update iOS wheel build script in workflow

### DIFF
--- a/.github/workflows/kivy_2.3.1.yml
+++ b/.github/workflows/kivy_2.3.1.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          ../kivy_scripts/kivy_master_build_ios_wheels.sh
+          ../kivy_scripts/kivy_build_ios_wheels.sh
 
       - run: ls build/wheels
 


### PR DESCRIPTION
Replaces the use of kivy_master_build_ios_wheels.sh with kivy_build_ios_wheels.sh in the GitHub Actions workflow for Kivy 2.3.1. This likely reflects a script rename or change in build process.