### PR TITLE
Add scripts and patches for iOS wheel builds

### DIFF
--- a/kivy_scripts/audiostream_build_ios_wheels.sh
+++ b/kivy_scripts/audiostream_build_ios_wheels.sh
@@ -1,0 +1,47 @@
+
+SCRIPT_DIR="$(dirname $0)"
+TOOLS=$SCRIPT_DIR/tools
+
+#git clone https://github.com/kivy/audiostream
+
+cp -f $TOOLS/audiostream/pyproject.toml audiostream/
+
+
+
+SDL_ROOT=$PWD/kivy-sdl3-angle/src
+
+SDK_ROOT="$(xcrun --show-sdk-path --sdk $SDK)"
+ARCHS="$ARCH"_"$SDK"
+
+EGL_FW="$ANGLE_FWS/libEGL.xcframework/$PLATFORM/libEGL.framework"
+GLES_FW="$ANGLE_FWS/libGLESv2.xcframework/$PLATFORM/libGLESv2.framework"
+
+PLATFORM=ios-arm64
+
+SDL3_HEADERS=$SDL_ROOT/SDL3_Headers
+SDL_FW="$SDL_ROOT/SDL3.xcframework/$PLATFORM/SDL3.framework"
+SDL_IMAGE_FW="$SDL_ROOT/SDL3_image.xcframework/$PLATFORM/SDL3_image.framework"
+SDL_MIXER_FW="$SDL_ROOT/SDL3_mixer.xcframework/$PLATFORM/SDL3_mixer.framework"
+SDL_TTF_FW="$SDL_ROOT/SDL3_ttf.xcframework/$PLATFORM/SDL3_ttf.framework"
+
+
+ln -s $SDL_FW/SDL3                  $SDL_FW/libSDL3.dylib
+ln -s $SDL_MIXER_FW/SDL3_mixer      $SDL_MIXER_FW/libSDL3_mixer.dylib
+
+export SDL2_INCLUDE_DIR=$SDL_FW/ios-arm64/SDL3.framework/Headers
+export USE_SDL2=1
+export KIVY_SDL3_FRAMEWORKS_SEARCH_PATH=$SDL_FW
+export "CFLAGS=-I$SDL_FW/ios-arm64/SDL3.framework/Headers"
+
+export KIVYIOSROOT=$ROOT
+export IOSSDKROOT=$SDK_ROOT
+
+ARCH=arm64
+
+LDFLAGS="-arch $ARCH \
+    -L$SDL_FW \
+    -L$SDL_MIXER_FW \
+    "
+export "LDFLAGS=$LDFLAGS"
+
+cibuildwheel audiostream --platform ios --archs arm64_iphoneos 

--- a/kivy_scripts/pyobjus_build_ios_wheels.sh
+++ b/kivy_scripts/pyobjus_build_ios_wheels.sh
@@ -1,0 +1,17 @@
+
+
+SCRIPT="$(realpath $0)"
+SCRIPT_DIR="$(dirname $SCRIPT)"
+TOOLS=$SCRIPT_DIR/tools
+
+SDK_ROOT="$(xcrun --show-sdk-path --sdk iphoneos)"
+
+git clone https://github.com/kivy/pyobjus
+
+patch -t -d pyobjus -p1 -i $TOOLS/pyobjus.patch
+cp -f  $TOOLS/pyobjus.__init__.py pyobjus/pyobjus/__init__.py
+
+export CFLAGS="-I$SDK_ROOT/usr/include -I$PWD/opt/include"
+export LDFLAGS="-arch arm64 -L$PWD/opt/lib"
+
+cibuildwheel pyobjus --platform ios --archs arm64_iphoneos --output-dir $1

--- a/kivy_scripts/tools/audiostream/pyproject.toml
+++ b/kivy_scripts/tools/audiostream/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools~=69.2.0",
+    "wheel~=0.44.0",
+    "packaging>=24.0",
+    "cython>=0.29.1,<=3.0.11",
+]
+

--- a/kivy_scripts/tools/pyobjus.__init__.py
+++ b/kivy_scripts/tools/pyobjus.__init__.py
@@ -1,0 +1,2 @@
+__version__ = '1.2.3'
+from .pyobjus import *

--- a/kivy_scripts/tools/pyobjus.patch
+++ b/kivy_scripts/tools/pyobjus.patch
@@ -1,0 +1,86 @@
+diff --git a/pyobjus/_runtime.h b/pyobjus/_runtime.h
+index c31b7ba..6d0cf85 100644
+--- a/pyobjus/_runtime.h
++++ b/pyobjus/_runtime.h
+@@ -1,6 +1,6 @@
+ #include <objc/runtime.h>
+ #include <objc/message.h>
+-#include <ffi/ffi.h>
++#include <ffi.h>
+ #include <stdio.h>
+ #include <dlfcn.h>
+ #include <string.h>
+diff --git a/pyobjus/common.pxi b/pyobjus/common.pxi
+index 3a17bbb..4f43c6a 100644
+--- a/pyobjus/common.pxi
++++ b/pyobjus/common.pxi
+@@ -109,7 +109,7 @@ cdef extern from "objc/runtime.h":
+     objc_method_description* protocol_copyMethodDescriptionList(Protocol *p, BOOL isRequiredMethod, BOOL isInstanceMethod, unsigned int *outCount)
+ 
+ 
+-cdef extern from "ffi/ffi.h":
++cdef extern from "ffi.h":
+     ctypedef unsigned long  ffi_arg
+     ctypedef signed long    ffi_sarg
+     ctypedef enum: FFI_TYPE_STRUCT
+diff --git a/setup.py b/setup.py
+index 0de7708..c8deb36 100644
+--- a/setup.py
++++ b/setup.py
+@@ -20,13 +20,7 @@ if kivy_ios_root is not None:
+ print("Pyobjus platform is {}".format(dev_platform))
+ 
+ # OSX
+-files = []
+-if dev_platform == 'darwin':
+-    files = ['pyobjus.pyx']
+-# iOS
+-elif dev_platform == 'ios':
+-    files = ['pyobjus.c']
+-
++files = ['pyobjus.pyx']
+ 
+ class PyObjusBuildExt(build_ext, object):
+ 
+@@ -43,13 +37,10 @@ class PyObjusBuildExt(build_ext, object):
+         # The following essentially supply a dynamically generated subclass
+         # that mix in the cython version of build_ext so that the
+         # functionality provided will also be executed.
+-        if dev_platform != 'ios':
+-            from Cython.Distutils import build_ext as cython_build_ext
+-            build_ext_cls = type(
+-                'PyObjusBuildExt', (PyObjusBuildExt, cython_build_ext), {})
+-            return super(PyObjusBuildExt, cls).__new__(build_ext_cls)
+-        else:
+-            return super(PyObjusBuildExt, cls).__new__(cls)
++        from Cython.Distutils import build_ext as cython_build_ext
++        build_ext_cls = type(
++            'PyObjusBuildExt', (PyObjusBuildExt, cython_build_ext), {})
++        return super(PyObjusBuildExt, cls).__new__(build_ext_cls)
+ 
+     def build_extensions(self):
+         # create a configuration file for pyobjus (export the platform)
+@@ -57,11 +48,9 @@ class PyObjusBuildExt(build_ext, object):
+         config_pxi_need_update = True
+         config_pxi = 'DEF PLATFORM = "{}"\n'.format(dev_platform)
+         config_pxi += 'DEF ARCH = "{}"\n'.format(arch)
+-        if dev_platform == 'ios':
+-            cython3 = False # Assume Cython 0.29, which is what we use for kivy-ios (ATM)
+-        else:
+-            import Cython
+-            cython3 = Cython.__version__.startswith('3.')
++
++        import Cython
++        cython3 = Cython.__version__.startswith('3.')
+         config_pxi += f"DEF PYOBJUS_CYTHON_3 = {cython3}"
+         if exists(config_pxi_fn):
+             with open(config_pxi_fn) as fd:
+@@ -73,7 +62,7 @@ class PyObjusBuildExt(build_ext, object):
+         super().build_extensions()
+ 
+ 
+-libraries = ['ffi']
++libraries = ['ffi', 'objc']
+ library_dirs = []
+ extra_compile_args = []
+ extra_link_args = []


### PR DESCRIPTION
Introduces build scripts for audiostream and pyobjus iOS wheels, including necessary patches and configuration files. These changes facilitate building and packaging the libraries for iOS arm64 using cibuildwheel, and include updates to pyobjus to improve compatibility and build process.