### PR TITLE
Add GitHub Actions workflow for Kivy iOS wheels

### DIFF
--- a/.github/workflows/kivy_ios.yml
+++ b/.github/workflows/kivy_ios.yml
@@ -1,0 +1,84 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build kivy-ios iOS Wheels
+
+# Controls when the workflow will run
+on:
+  workflow_dispatch:
+    # inputs:
+    #   tag:
+    #     description: 'input new release tag'
+    #     required: true
+    #     type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    name: Build Kivy iOS Wheels
+    # The type of runner that the job will run on
+    #runs-on: self-hosted
+    runs-on: macos-14
+    permissions:
+        contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+      
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13.7'
+      #- uses: actions/setup-python@v6
+      #  with:
+      #    python-version: '3.14.rc3'
+
+      - name: install cibuildwheel
+        run: pip3.13 install cibuildwheel
+        
+      - name: build wheels
+        run: |
+          mkdir -p build/wheels
+          cd build
+          ../kivy_scripts/kivy_ios_build_ios_wheels.sh wheels
+
+      - run: ls build/wheels
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-output
+          path: ./build
+
+  anaconda_upload:
+    name: Upload to Anaconda
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-output
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13.7'
+
+      - name: install anaconda client
+        run: |
+          pip install anaconda-client anaconda-auth
+      
+      - name: publish-to-anaconda
+        run: |
+          anaconda login \
+              --at anaconda.org \
+              --username ${{ secrets.ANACONDA_USER }} \
+              --password "${{ secrets.ANACONDA_PASS }}"
+          cd wheels
+          for FILE in *
+          do
+            anaconda upload --force $FILE --summary "No Summary"
+          done
+          anaconda logout --at anaconda.org
+      
+
+          


### PR DESCRIPTION
Introduces a workflow to build Kivy iOS wheels on macOS and upload them to Anaconda. The workflow includes steps for building wheels using cibuildwheel and publishing artifacts to Anaconda after successful build.